### PR TITLE
Removed default popup from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,8 +14,7 @@
       "48": "icons/icon48-gray.png",
       "128": "icons/icon128-gray.png"
     },
-    "default_title": "Strudel Devtools",
-    "default_popup": "popup/popup.html"
+    "default_title": "Strudel Devtools"
   },
   "content_scripts": [
     {


### PR DESCRIPTION
This PR will remove the default popup that displayed an error message while clicking on extension icon.