### PR TITLE
Bugfix/1.0.0 compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,39 @@ WORK IN PROGRESS
 
 ## Introduction
 
- Google Chrome Dev Tools extension for debugging Strudel.js applications
- 
- ## Contributing
- 
- Coming soon
- 
- ## License
- 
- [MIT](https://opensource.org/licenses/MIT)
- 
- Copyright (c) 2017-present, Mateusz Łuczak
+Google Chrome Dev Tools extension for debugging Strudel.js applications
+
+### Windows
+- DevTools Panel - /src/devtools
+- Background - /src/background
+- Backend (injected into apge) - /src/backend
+
+### Events flow
+```
+/src/devtools        /src/core                  /src/backend/proxy
+
++----------+       +------------+               +----------------+
+|          |       |            |  sendMessage  |                |
+| DEVTOOLS +------>+ redux-saga +-------------->+ chrome.runtime |
+|          |       |            |               |   .onMessage   |
++--+-------+       +------------+               |                |
+   ^                                            +---+------------+
+   |                                                |
+   | /src/background           /src/backend/proxy   |  postMessage
+   |                                                v
+   |   +-------+            +-----------------------+------------+
+   |   |       |  dispatch  |                                    |
+   +---+ store +<-----------+ window.addEventListener('message') |
+       |       |            |                                    |
+       +-------+            +------------------------------------+
+```
+
+## Contributing
+
+Coming soon
+
+## License
+
+[MIT](https://opensource.org/licenses/MIT)
+
+Copyright (c) 2017-present, Mateusz Łuczak

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Google Chrome Dev Tools extension for debugging Strudel.js applications
 ### Windows
 - DevTools Panel - /src/devtools
 - Background - /src/background
-- Backend (injected into apge) - /src/backend
+- Backend (injected into the page) - /src/backend
 
 ### Events flow
 ```

--- a/src/backend/events.js
+++ b/src/backend/events.js
@@ -1,4 +1,5 @@
 import { stringify } from '../core/transfer';
+import { getComponentName } from '../core/utils';
 
 const logEvent = (vm, type, eventName, payload) => {
   window.postMessage({
@@ -7,7 +8,7 @@ const logEvent = (vm, type, eventName, payload) => {
       eventName,
       type,
       payload: stringify(payload),
-      source: vm.constructor.name,
+      source: getComponentName(vm),
       timestamp: Date.now()
     }
   }, '*');

--- a/src/backend/highlighter.js
+++ b/src/backend/highlighter.js
@@ -38,6 +38,8 @@ const Highlighter = (() => {
     const el = document.createElement('div');
     const name = document.createElement('span');
 
+    el.addEventListener('mouseenter', detach);
+
     name.classList.add(`${HIGHLIGHTER_SELECTOR}-name`);
     el.append(name);
     el.classList.add(HIGHLIGHTER_SELECTOR);

--- a/src/backend/highlighter.js
+++ b/src/backend/highlighter.js
@@ -1,3 +1,5 @@
+import { getComponentName } from '../core/utils';
+
 const HIGHLIGHTER_SELECTOR = 'strudelDevtools-highlighter';
 
 const Highlighter = (() => {
@@ -11,7 +13,7 @@ const Highlighter = (() => {
     el.style.top = `${top + window.pageYOffset}px`;
     el.style.width = `${width}px`;
     el.style.height = `${height}px`;
-    name.innerText = component.__strudel__.constructor.name;
+    name.innerText = getComponentName(component.__strudel__);
   }
 
   function resetHighlighter() {

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -80,17 +80,25 @@ const adaptInstanceDetails = instance => {
     elements: {},
   };
 
+  function prepare(instance) {
+    return deepMap(instance, (el) => {
+      if (!el) return el;
+
+      if (el instanceof HTMLCollection) return Array.from(el);
+      if (el instanceof Element) {
+        el.__STRUDEL_DEVTOOLS__ISNODE__ = true;
+        return el;
+      }
+
+      return el.__strudel__ ? {...el, __strudel__: undefined, __STRUDEL_DEVTOOLS__ISNODE__: true} : el;
+    });
+  }
+
   Object.keys(instance).forEach((property) => {
     if (instance[property] && getComponentName(instance[property]) === 'Element' && property !== '$element') {
-      adapted.elements[property] = deepMap(instance[property], (el) => {
-        if (!el) return el;
-        return el.__strudel__ ? {...el, __strudel__: undefined, _isNode: true} : el;
-      });
+      adapted.elements[property] = prepare(instance[property]);
     } else if (!reservedKeys.includes(property)) {
-      adapted.properties[property] = deepMap(instance[property], (el) => {
-        if (!el) return el;
-        return el.__strudel__ ? {...el, __strudel__: undefined, _isNode: true} : el;
-      });
+      adapted.properties[property] = prepare(instance[property]);
     }
   });
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -72,7 +72,7 @@ const adaptInstanceDetails = instance => {
   ];
   const adapted = {
     info: {
-      name: instance.constructor.name,
+      name: getComponentName(instance),
       selector: instance.__proto__._selector,
     },
     dataAttrs: instance.$data,
@@ -84,7 +84,11 @@ const adaptInstanceDetails = instance => {
     if (instance[property] && getComponentName(instance[property]) === 'Element' && property !== '$element') {
       adapted.elements[property] = instance[property];
     } else if (!reservedKeys.includes(property)) {
-      adapted.properties[property] = instance[property];
+      if(!instance[property].__strudel__) {
+        adapted.properties[property] = instance[property];
+      } else {
+        adapted.properties[property] = "HTMLElement";
+      }
     }
   });
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -2,7 +2,6 @@ import { init, TYPES } from '../core/actions';
 import { initEventsBackend } from './events';
 import { Highlighter } from './highlighter';
 import { stringify } from 'flatted/esm';
-import { getComponentName } from '../core/utils';
 import { getComponentName, deepMap } from '../core/utils';
 
 const hook = window.__STRUDEL_DEVTOOLS_GLOBAL_HOOK__;
@@ -69,7 +68,6 @@ const getInstanceDetails = (instance) => ({
 
 const adaptInstanceDetails = instance => {
   const reservedKeys = [
-    'name', 'selector', '$data', '$element', '__STRUDEL_DEVTOOLS_UID__'
     'name', 'selector', '$data', '$element', '__STRUDEL_DEVTOOLS_UID__', '_els', '_events'
   ];
   const adapted = {
@@ -86,12 +84,12 @@ const adaptInstanceDetails = instance => {
     if (instance[property] && getComponentName(instance[property]) === 'Element' && property !== '$element') {
       adapted.elements[property] = deepMap(instance[property], (el) => {
         if (!el) return el;
-        return el.__strudel__ ? {...el, __strudel__: undefined} : el;
+        return el.__strudel__ ? {...el, __strudel__: undefined, _isNode: true} : el;
       });
     } else if (!reservedKeys.includes(property)) {
       adapted.properties[property] = deepMap(instance[property], (el) => {
         if (!el) return el;
-        return el.__strudel__ ? {...el, __strudel__: undefined} : el;
+        return el.__strudel__ ? {...el, __strudel__: undefined, _isNode: true} : el;
       });
     }
   });

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -3,6 +3,7 @@ import { initEventsBackend } from './events';
 import { Highlighter } from './highlighter';
 import { stringify } from 'flatted/esm';
 import { getComponentName } from '../core/utils';
+import { getComponentName, deepMap } from '../core/utils';
 
 const hook = window.__STRUDEL_DEVTOOLS_GLOBAL_HOOK__;
 let uid = 0;
@@ -69,6 +70,7 @@ const getInstanceDetails = (instance) => ({
 const adaptInstanceDetails = instance => {
   const reservedKeys = [
     'name', 'selector', '$data', '$element', '__STRUDEL_DEVTOOLS_UID__'
+    'name', 'selector', '$data', '$element', '__STRUDEL_DEVTOOLS_UID__', '_els', '_events'
   ];
   const adapted = {
     info: {
@@ -82,13 +84,15 @@ const adaptInstanceDetails = instance => {
 
   Object.keys(instance).forEach((property) => {
     if (instance[property] && getComponentName(instance[property]) === 'Element' && property !== '$element') {
-      adapted.elements[property] = instance[property];
+      adapted.elements[property] = deepMap(instance[property], (el) => {
+        if (!el) return el;
+        return el.__strudel__ ? {...el, __strudel__: undefined} : el;
+      });
     } else if (!reservedKeys.includes(property)) {
-      if(!instance[property].__strudel__) {
-        adapted.properties[property] = instance[property];
-      } else {
-        adapted.properties[property] = "HTMLElement";
-      }
+      adapted.properties[property] = deepMap(instance[property], (el) => {
+        if (!el) return el;
+        return el.__strudel__ ? {...el, __strudel__: undefined} : el;
+      });
     }
   });
 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -68,7 +68,7 @@ const getInstanceDetails = (instance) => ({
 
 const adaptInstanceDetails = instance => {
   const reservedKeys = [
-    'name', 'selector', '$data', '$element', '__STRUDEL_DEVTOOLS_UID__', '_els', '_events'
+    'name', 'selector', '$data', '$element', '__STRUDEL_DEVTOOLS_UID__', '_els', '_events', "mixins"
   ];
   const adapted = {
     info: {

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -2,6 +2,7 @@ import { init, TYPES } from '../core/actions';
 import { initEventsBackend } from './events';
 import { Highlighter } from './highlighter';
 import { stringify } from 'flatted/esm';
+import { getComponentName } from '../core/utils';
 
 const hook = window.__STRUDEL_DEVTOOLS_GLOBAL_HOOK__;
 let uid = 0;
@@ -61,7 +62,7 @@ const walk = (node, fn) => {
 }
 
 const getInstanceDetails = (instance) => ({
-  name: instance.constructor.name,
+  name: getComponentName(instance),
   selector: instance.__proto__._selector
 });
 
@@ -80,8 +81,7 @@ const adaptInstanceDetails = instance => {
   };
 
   Object.keys(instance).forEach((property) => {
-    if (instance[property] && instance[property].constructor && instance[property].constructor.name === 'Element' &&
-        property !== '$element') {
+    if (instance[property] && getComponentName(instance[property]) === 'Element' && property !== '$element') {
       adapted.elements[property] = instance[property];
     } else if (!reservedKeys.includes(property)) {
       adapted.properties[property] = instance[property];

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -22,15 +22,15 @@ export const getComponentName = (component) => {
 
 const deep = (obj, fn, last) => {
   // Primirives
-  if(obj !== Object(obj)) return fn(obj);
+  if (obj !== Object(obj)) return fn(obj);
 
-  if(obj._seen === true || last === true) return;
+  if (obj._seen === true || last === true) return;
 
-  if(obj instanceof Element) last = true;
+  if (obj instanceof Element) last = true;
 
   const newObj = fn(obj);
 
-  if(newObj instanceof HTMLFormElement || newObj instanceof HTMLCollection) {
+  if (newObj instanceof HTMLFormElement || newObj instanceof HTMLCollection) {
     return newObj;
   }
 
@@ -45,7 +45,7 @@ const deep = (obj, fn, last) => {
       newObj._seen = true;
       newObj[key] = deep(newObj[key], fn, last);
     } catch(err) {console.error('->', newObj, key, err)}
-    if(newObj[key] === undefined) delete newObj[key];
+    if (newObj[key] === undefined) delete newObj[key];
   });
 
   delete newObj._seen;

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -20,13 +20,9 @@ export const getComponentName = (component) => {
     : component.constructor.name;   // Strudel < 1.0.0
 }
 
-const deep = (obj, fn, last) => {
-  // Primirives
+const deep = (obj, fn) => {
   if (obj !== Object(obj)) return fn(obj);
-
-  if (obj._seen === true || last === true) return;
-
-  if (obj instanceof Element) last = true;
+  if (obj.__STRUDEL_DEVTOOLS_SEEN__ === true) return;
 
   const newObj = fn(obj);
 
@@ -34,21 +30,17 @@ const deep = (obj, fn, last) => {
     return newObj;
   }
 
-  // Array
   if (Array.isArray(newObj)) {
-    return newObj.map(e => deepMap(e, fn, last));
+    return newObj.map(e => deepMap(e, fn));
   }
 
-  // Objects
   Object.keys(newObj).map(key => {
-    try {
-      newObj._seen = true;
-      newObj[key] = deep(newObj[key], fn, last);
-    } catch(err) {console.error('->', newObj, key, err)}
+    newObj.__STRUDEL_DEVTOOLS_SEEN__ = true;
+    newObj[key] = deep(newObj[key], fn);
     if (newObj[key] === undefined) delete newObj[key];
   });
 
-  delete newObj._seen;
+  delete newObj.__STRUDEL_DEVTOOLS_SEEN__;
   return newObj;
 }
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -12,3 +12,10 @@ export const assignTabState = (state) => {
     events: state && state.events ? state.events : [],
   });
 };
+
+export const getComponentName = (component) => {
+  if(!component || !component.constructor) throw new Error("Provided parameter isn't valid Strudel Element");
+  return component.constructor.name === "component"
+    ? component.name                // Strudel >= 1.0.0
+    : component.constructor.name;   // Strudel < 1.0.0
+}

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -23,7 +23,7 @@ export const getComponentName = (component) => {
 export const deepMap = (obj, fn) => {
   const newObj = fn(obj);
 
-  if ((test !== Object(obj)) {
+  if (obj !== Object(obj)) {
     return fn(obj);
   }
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -14,8 +14,26 @@ export const assignTabState = (state) => {
 };
 
 export const getComponentName = (component) => {
-  if(!component || !component.constructor) throw new Error("Provided parameter isn't valid Strudel Element");
+  if (!component || !component.constructor) throw new Error("Provided parameter isn't valid Strudel Element");
   return component.constructor.name === "component"
     ? component.name                // Strudel >= 1.0.0
     : component.constructor.name;   // Strudel < 1.0.0
+}
+
+export const deepMap = (obj, fn) => {
+  const newObj = fn(obj);
+
+  if ((test !== Object(obj)) {
+    return fn(obj);
+  }
+
+  if (Array.isArray(newObj)) {
+    return newObj.map(e => deepMap(e, fn));
+  }
+
+  Object.keys(obj).map(key => {
+    newObj[key] = deepMap(newObj[key], fn);
+  });
+
+  return newObj;
 }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -26,7 +26,7 @@ export const getComponentName = (component) => {
   If result is Array, returns new array with the results of calling `deepMapStrudelInstance` function for every array element.
   If result is Object, returns it after executing `deepMapStrudelInstance` function for all its fields.
 
-  Function deletes undefined fields and breaks circulars in objects.
+  Function deletes undefined fields and removes circular references in objects.
 */
 export const deepMapStrudelInstance = (obj, fn) => {
     if (!obj || obj.__STRUDEL_DEVTOOLS_SEEN__ === true) return;

--- a/src/devtools/components/Property.js
+++ b/src/devtools/components/Property.js
@@ -44,7 +44,7 @@ class Property extends Component {
 
   HTMLElemInspect(e) {
     const { parent, prop, selectedComponentId, value } = this.props;
-    if(value && value._isNode) {
+    if (value && value._isNode) {
       const ev = `inspect(window.__STRUDEL_DEVTOOLS_INSTANCE_MAP__.get(${selectedComponentId}).__strudel__.$element._nodes[0])`;
       chrome.devtools.inspectedWindow.eval(ev);
     } else {

--- a/src/devtools/components/Property.js
+++ b/src/devtools/components/Property.js
@@ -14,7 +14,7 @@ const valueType = (value) => {
     type === 'number'
   ) {
     return 'literal';
-  } else if (value === 'HTMLElement') {
+  } else if (value === 'HTMLElement' || (value && value._isNode)) {
     return 'HTML-element';
   } else if (type === 'string') {
     return 'string';
@@ -43,10 +43,15 @@ class Property extends Component {
   }
 
   HTMLElemInspect(e) {
-    const { parent, prop, selectedComponentId } = this.props;
-    const pathToParent = `${parent}._nodes`
-    const ev = `inspect(window.__STRUDEL_DEVTOOLS_INSTANCE_MAP__.get(${selectedComponentId}).__strudel__.${pathToParent}[${prop}])`;
-    chrome.devtools.inspectedWindow.eval(ev);
+    const { parent, prop, selectedComponentId, value } = this.props;
+    if(value && value._isNode) {
+      const ev = `inspect(window.__STRUDEL_DEVTOOLS_INSTANCE_MAP__.get(${selectedComponentId}).__strudel__.$element._nodes[0])`;
+      chrome.devtools.inspectedWindow.eval(ev);
+    } else {
+      const pathToParent = `${parent}._nodes`
+      const ev = `inspect(window.__STRUDEL_DEVTOOLS_INSTANCE_MAP__.get(${selectedComponentId}).__strudel__.${pathToParent}[${prop}])`;
+      chrome.devtools.inspectedWindow.eval(ev);
+    }
 
     e.stopPropagation();
   }
@@ -99,7 +104,7 @@ class Property extends Component {
             <span className="key">{prop}</span>
             <span className="colon">:</span>
             <span className={valueClassName}>
-              HTMLElement 
+              HTMLElement
               <Button class="crosshair" ariaLabel="Inspect element" clickHandler={this.HTMLElemInspect.bind(this)} />
             </span>
           </div>

--- a/src/devtools/components/Property.js
+++ b/src/devtools/components/Property.js
@@ -48,7 +48,7 @@ class Property extends Component {
       const ev = `inspect(window.__STRUDEL_DEVTOOLS_INSTANCE_MAP__.get(${selectedComponentId}).__strudel__.$element._nodes[0])`;
       chrome.devtools.inspectedWindow.eval(ev);
     } else {
-      const pathToParent = `${parent}._nodes`
+      const pathToParent = `${parent}._nodes`;
       const ev = `inspect(window.__STRUDEL_DEVTOOLS_INSTANCE_MAP__.get(${selectedComponentId}).__strudel__.${pathToParent}[${prop}])`;
       chrome.devtools.inspectedWindow.eval(ev);
     }

--- a/src/devtools/components/Property.js
+++ b/src/devtools/components/Property.js
@@ -14,7 +14,7 @@ const valueType = (value) => {
     type === 'number'
   ) {
     return 'literal';
-  } else if (value === 'HTMLElement' || (value && value._isNode)) {
+  } else if (value === 'HTMLElement' || (value && value.__STRUDEL_DEVTOOLS__ISNODE__)) {
     return 'HTML-element';
   } else if (type === 'string') {
     return 'string';

--- a/src/devtools/styles.css
+++ b/src/devtools/styles.css
@@ -155,6 +155,7 @@ input {
   height: calc(100vh - 64px);
   box-sizing: border-box;
   position: relative;
+  overflow-y: scroll;
 }
 
 .column+.column {


### PR DESCRIPTION
add `getComponentName` util
- the function helps to get a component name and it's compatible with old and new Strudel API 

handle strudel elements as properties
- provided a fallback for strudel elements in properties to keep serialization working